### PR TITLE
Fix link parameter

### DIFF
--- a/jenkins.1m.rb
+++ b/jenkins.1m.rb
@@ -109,7 +109,7 @@ def run
   puts '---'
   print_builds_summary(builds)
   puts '---'
-  puts 'Open In Browser | href= ' + URL
+  puts 'Open In Browser | href=' + URL
 end
 
 run


### PR DESCRIPTION
The plugin fails with the error "malformed parameters missing equals" if there is a space symbol between the "href=" parameter and the URL.